### PR TITLE
Add SecObserve to extensions

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -50,5 +50,6 @@ Add yours [with a pull request](https://github.com/returntocorp/semgrep-docs)!
 - [nodejsscan](https://github.com/ajinabraham/nodejsscan)
 - [SALUS](https://github.com/coinbase/salus/blob/master/docs/scanners/semgrep.md)
 - [ScanMyCode CE (Community Edition)](https://github.com/marcinguy/scanmycode-ce) 
+- [SecObserve](https://github.com/MaibornWolff/SecObserve) 
 
 <MoreHelp />


### PR DESCRIPTION
SecObserve is a vulnerability management that supports importing Semgrep reports

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
